### PR TITLE
clean stale placeholders and add explicit persistence links

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,16 +11,14 @@ This repo keeps adapter-specific documentation only. Shared architecture/product
 - [Repo Boundaries](https://github.com/idelstak/friction-core/blob/master/docs/REPO_BOUNDARIES.md)
 - [Versioning Policy](https://github.com/idelstak/friction-core/blob/master/docs/VERSIONING.md)
 
-## Adapter-Specific Docs to Add/Keep
+## Adapter-Specific Docs
 
-Add adapter-owned docs in this folder for:
+Adapter-owned docs in this folder include:
 
 - Source-specific ingestion behavior (Reddit now, others later)
 - Data mapping and normalization rules
 - Persistence adapter behavior and constraints
 - Operational runbooks (retries, backoff, error handling, rate limits)
-
-## Adapter-Specific Docs
 
 - [Reddit Ingestion Mapping and Runbook](./REDDIT_INGESTION_RUNBOOK.md)
 - [Persistence Adapter Behavior](./PERSISTENCE_BEHAVIOR.md)

--- a/docs/READ_MODELS.md
+++ b/docs/READ_MODELS.md
@@ -4,4 +4,6 @@ Canonical read-model contract lives in `friction-core`:
 
 - [friction-core/docs/READ_MODELS.md](https://github.com/idelstak/friction-core/blob/master/docs/READ_MODELS.md)
 
-Adapter-specific persistence behavior should be documented in this repo when introduced.
+Adapter-specific persistence behavior is documented here:
+
+- [Persistence Adapter Behavior](./PERSISTENCE_BEHAVIOR.md)


### PR DESCRIPTION
- Updated `docs/READ_MODELS.md` to remove stale "when introduced" wording.
- Added explicit direct link to `docs/PERSISTENCE_BEHAVIOR.md` from `docs/READ_MODELS.md`.
- Tightened `docs/README.md` wording to reflect current state (docs already exist).
- Consolidated adapter docs section wording for clearer navigation without duplicating canonical `friction-core` content.