### PR TITLE
Canonicalize adapters publish runbook contract

### DIFF
--- a/docs/PUBLISH_RUNBOOK.md
+++ b/docs/PUBLISH_RUNBOOK.md
@@ -1,0 +1,110 @@
+# Publish Runbook
+
+Use the working publish workflow template below exactly as written.
+Do not redesign or partially rewrite it unless you are intentionally replacing
+this release/publish model.
+
+## Rule
+
+- Source of truth: `docs/PUBLISH_RUNBOOK.md` template below.
+- Target file: `.github/workflows/publish.yml`.
+- Action: copy the template directly.
+
+## Required Invariants
+
+- `pom.xml` keeps:
+  - `distributionManagement.repository.id` = `github`
+  - publish URL = `https://maven.pkg.github.com/IdelsTak/friction-adapters`
+- Workflow keeps:
+  - `on.workflow_run.workflows: [Release]`
+  - `permissions.packages: write`
+  - tag checkout + tag/pom version validation before `mvn deploy`
+  - deploy step with `GITHUB_TOKEN` env
+
+## Working `publish.yml` Template
+
+```yaml
+---
+name: Publish Package
+
+'on':
+  workflow_run:
+    workflows:
+      - Release
+    types:
+      - completed
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: publish-master
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: publish
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout master
+        uses: actions/checkout@v4
+        with:
+          ref: master
+          fetch-depth: 0
+
+      - name: Resolve latest release tag
+        id: tag
+        run: |
+          set -euo pipefail
+          git fetch --tags --force
+          latest_tag="$(
+            git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -n 1
+          )"
+          if [[ -z "${latest_tag}" ]]; then
+            echo "No stable semver tag found (expected vX.Y.Z)."
+            exit 1
+          fi
+          echo "tag=${latest_tag}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout latest tag
+        run: |
+          set -euo pipefail
+          git checkout "${{ steps.tag.outputs.tag }}"
+
+      - name: Install xmlstarlet
+        run: sudo apt-get update && sudo apt-get install -y xmlstarlet
+
+      - name: Validate pom.xml matches tag
+        run: |
+          set -euo pipefail
+          tag="${{ steps.tag.outputs.tag }}"
+          tag_version="${tag#v}"
+          pom_version="$(
+            xmlstarlet sel -t \
+              -v "/*[local-name()='project']/*[local-name()='version']" \
+              pom.xml
+          )"
+          if [[ "${pom_version}" != "${tag_version}" ]]; then
+            echo "pom.xml version (${pom_version})"
+            echo "does not match tag (${tag_version})"
+            exit 1
+          fi
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 25
+          server-id: github
+          server-username: GITHUB_ACTOR
+          server-password: GITHUB_TOKEN
+
+      - name: Publish
+        run: mvn -B -DskipTests deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,3 +24,4 @@ Adapter-owned docs in this folder include:
 - [Persistence Adapter Behavior](./PERSISTENCE_BEHAVIOR.md)
 - [Workflow Development](./WORKFLOW_DEV.md)
 - [Versioning Notes](./VERSIONING.md)
+- [Publish Runbook](./PUBLISH_RUNBOOK.md)

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -17,3 +17,11 @@ This repo follows that policy for release labeling and pre-release staging.
   available in GitHub Packages.
 
 Do not use local jars or manual classpath wiring in CI.
+
+## Publishing
+
+Publish implementation details are defined only in
+`docs/PUBLISH_RUNBOOK.md`.
+
+Rule:
+- Keep `.github/workflows/publish.yml` aligned to the runbook template exactly.

--- a/docs/WORKFLOW_DEV.md
+++ b/docs/WORKFLOW_DEV.md
@@ -71,6 +71,11 @@ Ensure workflow checks align with repo release policy:
 - `ci.yml` build/test step uses `secrets.PACKAGES_TOKEN` for package access.
 - CI must not rely on local/manual jars for `friction-core`.
 
+## Publish Reference
+
+`docs/PUBLISH_RUNBOOK.md` is the only source of truth for publish behavior.
+Use its template directly and avoid local variations.
+
 ## Release and Publish Workflows
 
 - `release.yml` (push to `master`):
@@ -82,15 +87,14 @@ Ensure workflow checks align with repo release policy:
     - `#<PR_NUMBER> <PR_TITLE>`
     - cleaned PR body
 - `publish.yml` (`workflow_run` on successful `Release`):
-  - checks out latest semver tag
-  - validates tag version equals `pom.xml` version
-  - publishes package via `mvn deploy`
+  - behavior is defined only by `docs/PUBLISH_RUNBOOK.md` template
 
 ## Permissions Baseline
 
 - `ci.yml`: `contents: read`, `packages: read`
 - `release.yml`: `contents: write`, `pull-requests: read`
-- `publish.yml`: `contents: read`, `packages: write`
+- `publish.yml` permissions and auth wiring are defined only in
+  `docs/PUBLISH_RUNBOOK.md`.
 
 ## Notes
 


### PR DESCRIPTION
This change establishes a single publish source of truth for `friction-adapters` by introducing `docs/PUBLISH_RUNBOOK.md` as the canonical operational contract. The runbook includes the required invariants for `distributionManagement`, workflow trigger and gating behavior, and token wiring, along with a full working `publish.yml` template that should be copied directly.

The workflow and versioning docs were tightened to prevent publish drift. `docs/WORKFLOW_DEV.md` now points publish behavior and auth details to the runbook instead of duplicating implementation details, and `docs/VERSIONING.md` now explicitly defers publish implementation to the runbook and requires alignment of `.github/workflows/publish.yml` with the template.

The docs index in `docs/README.md` now includes the publish runbook so maintainers can find the canonical guidance quickly and avoid alternate publish variants that previously caused errors.